### PR TITLE
Adds Gateway Deletion Support to Controller

### DIFF
--- a/internal/provider/kubernetes/controller.go
+++ b/internal/provider/kubernetes/controller.go
@@ -446,6 +446,9 @@ func (r *gatewayAPIReconciler) Reconcile(ctx context.Context, request reconcile.
 			return reconcile.Result{}, err
 		}
 
+		// Store the resource tree to trigger a delete operation.
+		r.resources.GatewayAPIResources.Store(acceptedGC.Name, resourceTree)
+
 		// No further processing is required as there are no Gateways for this GatewayClass
 		return reconcile.Result{}, nil
 	}

--- a/internal/provider/kubernetes/kubernetes_test.go
+++ b/internal/provider/kubernetes/kubernetes_test.go
@@ -161,11 +161,11 @@ func testGatewayClassAcceptedStatus(ctx context.Context, t *testing.T, provider 
 		return false
 	}, defaultWait, defaultTick)
 
-	// Since there are no Gateways present for the GatewayClass, we store nothing
-	// in the resource map.
+	// Even though no gateways exist, the controller loads the empty resource map
+	// to support gateway deletions.
 	require.Eventually(t, func() bool {
 		_, ok := resources.GatewayAPIResources.Load(gc.Name)
-		return !ok
+		return ok
 	}, defaultWait, defaultTick)
 }
 


### PR DESCRIPTION
Stores an empty resource map when no gateways exist to trigger a delete operation by the infra manager.

Signed-off-by: danehans <daneyonhansen@gmail.com>